### PR TITLE
Support Astro view transition

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -175,8 +175,4 @@ const initAstroLottie = async () => {
     }));
 }
 
-setTimeout(() => {
-    initAstroLottie();
-
-    document.addEventListener('astro:after-swap', initAstroLottie);
-}, 0);
+document.addEventListener('astro:page-load', initAstroLottie);

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,4 +45,15 @@ export type AstroLottie = {
      * Get all the LottieAnimation for the current page
      */
     getAllAnimations(): LottieAnimation[]
+
+    /**
+     * Get the current player mode
+     */
+    getPlayerMode(): "light" | "full"
+
+
+    /**
+     * Get the current observer
+     */
+    getObserver(): IntersectionObserver | undefined
 }


### PR DESCRIPTION
> In refer to https://github.com/giuseppelt/astro-lottie/issues/7, I refactorized the code by encapsulating it in various functions to make it more modular.
> 
> I used this event [astropage-load](https://docs.astro.build/it/guides/view-transitions/#astropage-load) for re-initialize the logic of this library.
> 
> If lottie has already been imported in full mode, it's reused to optimize page loading.

https://github.com/giuseppelt/astro-lottie/pull/10